### PR TITLE
Skip OOBE on Windows 10 after 18.03 version upgrade

### DIFF
--- a/UnattendTemplate.xml
+++ b/UnattendTemplate.xml
@@ -88,6 +88,7 @@
                 <ProtectYourPC>3</ProtectYourPC>
                 <NetworkLocation>Work</NetworkLocation>
                 <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
                 <!-- Comment the following two options on Windows Vista / 7 and Windows Server 2008 / 2008 R2 -->
                 <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
                 <HideLocalAccountScreen>true</HideLocalAccountScreen>


### PR DESCRIPTION
After Windows 10 updates are applied in order to upgrade to
version 18.03, a confirmation screen will appear, asking for
a user to accept the new privacy conditions.
As this breaks the automation process, a new OOBE directive is
added to the Unattend.xml so this can be skipped automatically.

Co-authored-by: Gabriel Samfira <gsamfira@cloudbasesolutions.com>